### PR TITLE
Use rubyarchhdrdir from RbConfig when available

### DIFF
--- a/lib/autorake/definition.rb
+++ b/lib/autorake/definition.rb
@@ -78,7 +78,9 @@ module Autorake
       else
         h = RbConfig::CONFIG[ "rubyhdrdir"]
         incdir :ruby, h
-        incdir :ruby_arch, (File.join h, RbConfig::CONFIG[ "arch"])
+        incdir :ruby_arch, RbConfig::CONFIG.fetch("rubyarchhdrdir") do
+          File.join h, RbConfig::CONFIG[ "arch"]
+        end
         #incdir :ruby_backward, (File.join h, "ruby/backward")
       end
       libdir :ruby, RbConfig::CONFIG[ "libdir"]


### PR DESCRIPTION
If RbConfig has an entry for `rubyarchhdrdir` use it rather than joining the platform-independent `rubyhdrdir` with the `arch`.  This is needed for the vendor ruby on current Debian and Ubuntu systems where the architecture dependent include files are in `/usr/include/x86_64-linux-gnu/ruby-2.1.0`.  The old method would result in the last two path components being switched.

Fall back to using the previous method if RbConfig doesn't define `rubyarchhdrdir`.
