### PR TITLE
Gemspec: Drop EOL'd property rubyforge_project

### DIFF
--- a/autorake.gemspec
+++ b/autorake.gemspec
@@ -6,7 +6,6 @@ require "./lib/autorake/version"
 
 Gem::Specification.new do |s|
   s.name              = Autorake::NAME
-  s.rubyforge_project = "NONE"
   s.version           = Autorake::VERSION
   s.summary           = Autorake::SUMMARY
   s.description       = Autorake::DESCRIPTION


### PR DESCRIPTION
The RubyGems property rubyforge_project is removed without a replacement.